### PR TITLE
Use correct Unicode characters for ellipsis and quotation

### DIFF
--- a/data/ui/torrent-row.ui
+++ b/data/ui/torrent-row.ui
@@ -245,7 +245,7 @@
                       <object class="GtkProgressBar" id="progress_bar">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="text" translatable="yes">Please wait...</property>
+                        <property name="text" translatable="yes">Please wait…</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/src/fragments-window.vala
+++ b/src/fragments-window.vala
@@ -114,7 +114,7 @@ public class Fragments.Window : Gtk.ApplicationWindow {
 
 	private void show_magnet_notification(string torrent_name){
 		notification_stack.set_visible_child_name("add-magnet");
-		magnet_notification_label.set_markup(_("Add magnet link <b>\"%s\"</b> from clipboard?").printf(torrent_name));
+		magnet_notification_label.set_markup(_("Add magnet link <b>“%s”</b> from clipboard?").printf(torrent_name));
 		notification_revealer.set_reveal_child(true);
 	}
 


### PR DESCRIPTION
Per recommendation from GNOME HIG