### PR TITLE
Spelling: Ellipsis instead of tripledot following "Wait".

### DIFF
--- a/po/fragments.pot
+++ b/po/fragments.pot
@@ -35,7 +35,7 @@ msgid "General"
 msgstr ""
 
 #: data/ui/torrent-row.ui:248
-msgid "Please wait..."
+msgid "Please wait…"
 msgstr ""
 
 #: data/ui/torrent-row.ui:391


### PR DESCRIPTION
To the tune of https://github.com/haecker-felix/Fragments/blob/841a71931cecf5603c28d1e167d3e8c2069cff70/data/ui/torrent-row.ui#L248