### PR TITLE
Spelling: Ellipsis instead of tripledot in build log

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,7 +5,7 @@ project(
   meson_version: '>= 0.40.0'
 )
 
-message('Build libtransmission. Please wait, this will take a moment...')
+message('Build libtransmission. Please wait, this will take a moment…')
 build = run_command('sh', 'build-aux/build_libtransmission.sh')
 if build.returncode() != 0
   message('Build failed. Please create new issue with complete build log at: https://github.com/haecker-felix/Fragments/issues/new')


### PR DESCRIPTION
This is not translatable, but IMO it should be.