### PR TITLE
Redesign settings window

### DIFF
--- a/data/ui/settings-window.ui
+++ b/data/ui/settings-window.ui
@@ -20,24 +20,24 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="margin_top">22</property>
-            <property name="margin_bottom">22</property>
+            <property name="margin_start">20</property>
+            <property name="margin_end">20</property>
+            <property name="margin_top">20</property>
+            <property name="margin_bottom">20</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="row_spacing">6</property>
-                <property name="column_spacing">12</property>
-                <property name="row_homogeneous">True</property>
-                <property name="column_homogeneous">True</property>
+                <property name="column_spacing">20</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">end</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
                     <property name="label" translatable="yes">Use dark theme</property>
                   </object>
                   <packing>
@@ -49,7 +49,7 @@
                   <object class="GtkSwitch" id="dark_theme_switch">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="halign">start</property>
+                    <property name="halign">end</property>
                     <property name="valign">center</property>
                   </object>
                   <packing>
@@ -61,7 +61,8 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">end</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
                     <property name="label" translatable="yes">Maximum active downloads</property>
                   </object>
                   <packing>
@@ -73,7 +74,8 @@
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">end</property>
+                    <property name="halign">start</property>
+                    <property name="hexpand">True</property>
                     <property name="label" translatable="yes">Download folder</property>
                   </object>
                   <packing>
@@ -85,7 +87,6 @@
                   <object class="GtkSpinButton" id="max_downloads_spinbutton">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
-                    <property name="halign">start</property>
                     <property name="adjustment">max_downloads_adjustment</property>
                     <property name="numeric">True</property>
                   </object>
@@ -96,10 +97,10 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="download_folder_button">
+                    <property name="width_request">200</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">True</property>
-                    <property name="halign">start</property>
                     <child>
                       <object class="GtkBox">
                         <property name="visible">True</property>
@@ -121,7 +122,6 @@
                           <object class="GtkLabel" id="download_folder_label">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="no"></property>
                             <property name="ellipsize">start</property>
                             <property name="max_width_chars">20</property>
                           </object>


### PR DESCRIPTION
This PR changes the layout of the settings window to be more in line with native Gnome apps like Tweaks.

IMO, this also looks cleaner as the columns are better aligned and it disallows the download folder button to reach the window edge. Below is a comparison of the layouts.

![fragments-settings-window-old](https://user-images.githubusercontent.com/13943260/45055770-1d1d3500-b091-11e8-929b-28614e662427.png)  
*Old layout*

![fragments-settings-window-new](https://user-images.githubusercontent.com/13943260/45055773-20182580-b091-11e8-9730-9e245443c1dd.png)  
*New layout*

Please let me know what you think of it.