### PR TITLE
torrent-row: Align ellipsizable labels on start

### DIFF
--- a/data/ui/torrent-row.ui
+++ b/data/ui/torrent-row.ui
@@ -169,6 +169,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
+                                <property name="xalign">0</property>
                                 <property name="label">Name</property>
                                 <property name="ellipsize">end</property>
                                 <property name="single_line_mode">True</property>
@@ -199,6 +200,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">start</property>
+                                <property name="xalign">0</property>
                                 <property name="label">-</property>
                                 <property name="ellipsize">end</property>
                                 <property name="single_line_mode">True</property>
@@ -851,3 +853,4 @@
     </style>
   </template>
 </interface>
+


### PR DESCRIPTION
This avoids jitter in the ellipsizable labels of the torrent row when resizing the window.